### PR TITLE
Add endpoint for exposing all the labels

### DIFF
--- a/email_classifier_brain/main.py
+++ b/email_classifier_brain/main.py
@@ -289,6 +289,13 @@ def get_read_notifications(
     notifs = database.get_read_notifications(start_time, end_time)
     return notifs
 
+@app.get("/labels", response_model=List[str])
+def get_labels():
+    """
+    Get all supported labels (categories) for email classification.
+    """
+    return classify.get_available_categories()
+
 @app.get("/health")
 def health_check():
     """

--- a/email_classifier_brain/tests/test_app.py
+++ b/email_classifier_brain/tests/test_app.py
@@ -201,3 +201,13 @@ def test_get_read_notifications(client, mock_imap_client, mock_classify_function
     assert len(read_notifs) == 1
     assert read_notifs[0]["subject"] == "Test Read"
     assert read_notifs[0]["is_read"] == 1
+
+def test_get_labels(client, mock_classify_functions):
+    """Test the /labels endpoint."""
+    expected_labels = ["FOCUS", "NOISE", "REFERENCE", "URGENT"]
+    mock_classify_functions.get_available_categories.return_value = expected_labels
+
+    response = client.get("/labels")
+    assert response.status_code == 200
+    assert response.json() == expected_labels
+    mock_classify_functions.get_available_categories.assert_called_once()


### PR DESCRIPTION
This PR adds a new endpoint `/labels` to the `email_classifier_brain` microservice. This endpoint allows clients to retrieve a list of all category labels that the application supports, which are derived from the fine-tuned ML model's label mapping.

Changes:
- Added `GET /labels` to `main.py`.
- Added a unit test in `test_app.py` to ensure the endpoint correctly returns the mocked categories.
- Verified all tests pass.

Fixes #5

---
*PR created automatically by Jules for task [3356392728014604719](https://jules.google.com/task/3356392728014604719) started by @lohnn*