### PR TITLE
feat: real health check on GET /health

### DIFF
--- a/email_classifier_brain/main.py
+++ b/email_classifier_brain/main.py
@@ -896,16 +896,25 @@ def get_ambiguous_logs():
     return database.get_ambiguous_logs()
 
 @app.get("/health")
-def health_check(check_imap: bool = Query(False, description="Also verify IMAP connectivity")):
+def health_check(
+    check_imap: bool = Query(False, description="Also verify IMAP connectivity (requires X-API-Key)"),
+    api_key: str = Security(api_key_scheme),
+):
     """
     Health check endpoint.
 
     Always verifies DB connectivity and model load state.
-    Pass ?check_imap=true to also probe IMAP reachability.
+    Pass ?check_imap=true to also probe IMAP reachability (requires X-API-Key header).
 
     Returns HTTP 200 when healthy or degraded (optional IMAP failure only).
     Returns HTTP 503 when a critical component (DB or model) is unavailable.
     """
+    # IMAP check is gated behind authentication to prevent unauthenticated DoS
+    if check_imap:
+        expected_key = os.getenv("ADMIN_API_KEY")
+        if not expected_key or api_key != expected_key:
+            raise HTTPException(status_code=401, detail="X-API-Key required to use check_imap")
+
     checks: dict = {}
     critical_ok = True
     degraded = False
@@ -917,7 +926,8 @@ def health_check(check_imap: bool = Query(False, description="Also verify IMAP c
         conn.close()
         checks["database"] = {"status": "ok"}
     except Exception as e:
-        checks["database"] = {"status": "error", "detail": str(e)}
+        logger.error(f"Health check DB error: {e}")
+        checks["database"] = {"status": "error", "detail": "Database connectivity error"}
         critical_ok = False
 
     # --- Model loaded state ---
@@ -927,23 +937,23 @@ def health_check(check_imap: bool = Query(False, description="Also verify IMAP c
         checks["model"] = {"status": "not_loaded"}
         critical_ok = False
 
-    # --- IMAP reachability (optional) ---
+    # --- IMAP reachability (optional, authenticated) ---
     if check_imap:
-        imap_user = os.getenv("IMAP_USER") or (os.getenv("MY_EMAIL") or "").split(",")[0].strip()
-        if not imap_user or not os.getenv("IMAP_PASSWORD"):
+        client = None
+        try:
+            client = imap_client.GmailClient()
+            client.connect()
+            checks["imap"] = {"status": "ok"}
+        except ValueError:
+            # GmailClient.connect() raises ValueError when credentials are not configured
             checks["imap"] = {"status": "not_configured"}
-        else:
-            client = None
-            try:
-                client = imap_client.GmailClient()
-                client.connect()
-                checks["imap"] = {"status": "ok"}
-            except Exception as e:
-                checks["imap"] = {"status": "error", "detail": str(e)}
-                degraded = True
-            finally:
-                if client:
-                    client.disconnect()
+        except Exception as e:
+            logger.error(f"Health check IMAP error: {e}")
+            checks["imap"] = {"status": "error", "detail": "IMAP connectivity error"}
+            degraded = True
+        finally:
+            if client:
+                client.disconnect()
 
     if not critical_ok:
         overall = "error"

--- a/email_classifier_brain/tests/test_app.py
+++ b/email_classifier_brain/tests/test_app.py
@@ -228,7 +228,7 @@ def test_health_ok_when_model_loaded(client):
 
 
 def test_health_db_error(client):
-    """A DB failure marks the check as error and returns 503."""
+    """A DB failure marks the check as error and returns 503 with a generic message."""
     with patch("classify._model", new=MagicMock()):
         with patch("database.get_db_connection", side_effect=Exception("db unavailable")):
             response = client.get("/health")
@@ -236,18 +236,22 @@ def test_health_db_error(client):
     data = response.json()
     assert data["status"] == "error"
     assert data["checks"]["database"]["status"] == "error"
-    assert "db unavailable" in data["checks"]["database"]["detail"]
+    # Generic message — raw exception detail must not be exposed
+    assert data["checks"]["database"]["detail"] == "Database connectivity error"
 
 
-def test_health_imap_not_configured(client):
-    """When check_imap=true but no IMAP credentials are set, reports not_configured."""
+def test_health_imap_requires_auth(client):
+    """check_imap=true without a valid API key returns 401."""
     with patch("classify._model", new=MagicMock()):
-        with patch.dict(os.environ, {}, clear=False):
-            # Ensure IMAP env vars are absent
-            os.environ.pop("IMAP_USER", None)
-            os.environ.pop("IMAP_PASSWORD", None)
-            os.environ.pop("MY_EMAIL", None)
-            response = client.get("/health?check_imap=true")
+        response = client.get("/health?check_imap=true")
+    assert response.status_code == 401
+
+
+def test_health_imap_not_configured(client, mock_imap_client):
+    """When check_imap=true but no IMAP credentials are set, reports not_configured."""
+    mock_imap_client.return_value.connect.side_effect = ValueError("IMAP_USER (or MY_EMAIL) and IMAP_PASSWORD must be set in .env")
+    with patch("classify._model", new=MagicMock()):
+        response = client.get("/health?check_imap=true", headers={"X-API-Key": "testkey"})
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
@@ -257,8 +261,7 @@ def test_health_imap_not_configured(client):
 def test_health_imap_ok(client, mock_imap_client):
     """When check_imap=true and IMAP connects successfully, reports ok."""
     with patch("classify._model", new=MagicMock()):
-        with patch.dict(os.environ, {"IMAP_USER": "user@example.com", "IMAP_PASSWORD": "secret"}):
-            response = client.get("/health?check_imap=true")
+        response = client.get("/health?check_imap=true", headers={"X-API-Key": "testkey"})
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
@@ -266,13 +269,13 @@ def test_health_imap_ok(client, mock_imap_client):
 
 
 def test_health_imap_error_is_degraded(client, mock_imap_client):
-    """An IMAP failure results in degraded (HTTP 200) not a hard error."""
+    """An IMAP failure results in degraded (HTTP 200) with a generic error message."""
     mock_imap_client.return_value.connect.side_effect = Exception("IMAP unreachable")
     with patch("classify._model", new=MagicMock()):
-        with patch.dict(os.environ, {"IMAP_USER": "user@example.com", "IMAP_PASSWORD": "secret"}):
-            response = client.get("/health?check_imap=true")
+        response = client.get("/health?check_imap=true", headers={"X-API-Key": "testkey"})
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "degraded"
     assert data["checks"]["imap"]["status"] == "error"
-    assert "IMAP unreachable" in data["checks"]["imap"]["detail"]
+    # Generic message — raw exception detail must not be exposed
+    assert data["checks"]["imap"]["detail"] == "IMAP connectivity error"


### PR DESCRIPTION
Replaces the trivial `{"status": "ok"}` response with actual checks against the database, model load state, and optionally IMAP.

Closes #40

Generated with [Claude Code](https://claude.ai/code)