### PR TITLE
feat: add retry logic with exponential backoff for IMAP, Git, and DB

### DIFF
--- a/email_classifier_brain/database.py
+++ b/email_classifier_brain/database.py
@@ -11,7 +11,7 @@ DB_FILE = config.DB_PATH
 
 def get_db_connection() -> sqlite3.Connection:
     """Create a database connection to the SQLite database."""
-    conn = sqlite3.connect(DB_FILE)
+    conn = sqlite3.connect(DB_FILE, timeout=10.0)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/email_classifier_brain/imap_client.py
+++ b/email_classifier_brain/imap_client.py
@@ -27,6 +27,17 @@ LABEL_TOKEN_PATTERN = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"|([^"\s()]+)')
 # Transient errors that warrant a retry (network drops, protocol aborts)
 _IMAP_ERRORS = (imaplib.IMAP4.error, OSError)
 
+
+def _imap_quote_label(label: str) -> str:
+    """Return label properly quoted and escaped for use in IMAP commands.
+
+    Escapes backslashes and double quotes so that a label value cannot
+    inject additional IMAP tokens or commands.
+    """
+    escaped = label.replace('\\', '\\\\').replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 class GmailClient:
     def __init__(self):
         # Prefer IMAP_USER, fallback to first email in MY_EMAIL
@@ -232,14 +243,13 @@ class GmailClient:
         Apply a label to the email using UID STORE +X-GM-LABELS.
         Accepts gmail_id (X-GM-MSGID).
         """
-        # Quote label if it has spaces
-        label_to_send = f'"{label}"' if " " in label else label
+        label_to_send = _imap_quote_label(label)
 
         def _do():
             self.connect()
             uid = self._search_by_gmail_id(gmail_id)
             if not uid:
-                print(f"Could not find email with Gmail ID {gmail_id} to apply label.")
+                logger.warning(f"Could not find email with Gmail ID {gmail_id} to apply label.")
                 return
             typ, data = self.connection.uid('STORE', uid, '+X-GM-LABELS', f'({label_to_send})')
             if typ != 'OK':
@@ -254,21 +264,20 @@ class GmailClient:
                 on_retry=lambda exc, _: self._reset_connection(),
             )
         except Exception as e:
-            print(f"Error applying label {label} to {gmail_id}: {e}")
+            logger.error(f"Error applying label {label} to {gmail_id}: {e}")
 
     def remove_label(self, gmail_id: str, label: str):
         """
         Remove a label from the email using UID STORE -X-GM-LABELS.
         Accepts gmail_id (X-GM-MSGID).
         """
-        # Quote label if it has spaces
-        label_to_send = f'"{label}"' if " " in label else label
+        label_to_send = _imap_quote_label(label)
 
         def _do():
             self.connect()
             uid = self._search_by_gmail_id(gmail_id)
             if not uid:
-                print(f"Could not find email with Gmail ID {gmail_id} to remove label.")
+                logger.warning(f"Could not find email with Gmail ID {gmail_id} to remove label.")
                 return
             typ, data = self.connection.uid('STORE', uid, '-X-GM-LABELS', f'({label_to_send})')
             if typ != 'OK':
@@ -283,7 +292,7 @@ class GmailClient:
                 on_retry=lambda exc, _: self._reset_connection(),
             )
         except Exception as e:
-            print(f"Error removing label {label} from {gmail_id}: {e}")
+            logger.error(f"Error removing label {label} from {gmail_id}: {e}")
 
     def fetch_email_by_gmail_id(self, gmail_id: str) -> Message:
         """
@@ -314,7 +323,7 @@ class GmailClient:
                 on_retry=lambda exc, _: self._reset_connection(),
             )
         except Exception as e:
-            print(f"Error fetching email {gmail_id}: {e}")
+            logger.error(f"Error fetching email {gmail_id}: {e}")
             return None
 
     def get_labels_for_emails(self, gmail_ids: List[str]) -> Dict[str, List[str]]:
@@ -423,7 +432,7 @@ class GmailClient:
                 on_retry=lambda exc, _: self._reset_connection(),
             )
         except Exception as e:
-            print(f"Error fetching labels batch: {e}")
+            logger.error(f"Error fetching labels batch: {e}")
             return {}
 
     def scan_labeled_emails(self, known_labels: List[str]) -> Dict[str, Tuple[List[str], Message]]:
@@ -442,8 +451,8 @@ class GmailClient:
 
             # Search for each known label
             for label in known_labels:
-                # X-GM-LABELS requires the label to be quoted
-                criteria = f'X-GM-LABELS "{label}"'
+                # X-GM-LABELS requires the label to be quoted and escaped
+                criteria = f'X-GM-LABELS {_imap_quote_label(label)}'
                 typ, data = self.connection.uid('SEARCH', None, criteria)
                 if typ == 'OK' and data[0]:
                     found_uids = data[0].split()

--- a/email_classifier_brain/imap_client.py
+++ b/email_classifier_brain/imap_client.py
@@ -8,6 +8,8 @@ from email.message import Message
 from typing import List, Optional, Tuple, Dict
 from dotenv import load_dotenv
 
+from retry import with_retry
+
 load_dotenv()
 
 IMAP_SERVER = os.getenv("IMAP_SERVER") or "imap.gmail.com"
@@ -21,6 +23,9 @@ X_GM_MSGID_PATTERN = re.compile(r'X-GM-MSGID (\d+)')
 SEQ_PATTERN = re.compile(r'^(\d+)')
 # Regex to parse individual labels from the list (handling quotes)
 LABEL_TOKEN_PATTERN = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"|([^"\s()]+)')
+
+# Transient errors that warrant a retry (network drops, protocol aborts)
+_IMAP_ERRORS = (imaplib.IMAP4.error, OSError)
 
 class GmailClient:
     def __init__(self):
@@ -62,6 +67,10 @@ class GmailClient:
                 pass
             self.connection = None
 
+    def _reset_connection(self):
+        """Drop the cached connection so the next call triggers a fresh connect."""
+        self.connection = None
+
     def fetch_unprocessed_emails(self, known_labels: List[str], limit: Optional[int] = None) -> List[Tuple[str, Message]]:
         """
         Fetch UNSEEN emails that do not have any of the known_labels.
@@ -73,143 +82,149 @@ class GmailClient:
                     newest-first, collecting qualifying sequence IDs up to limit.
           Phase 2 – fetch BODY.PEEK[] only for those qualifying IDs.
         """
-        self.connect()
+        def _do():
+            self.connect()
 
-        logger.info('Just about to search for unsees emails')
-        # Search for UNSEEN emails
-        typ, data = self.connection.search(None, 'UNSEEN')
+            logger.info('Just about to search for unsees emails')
+            # Search for UNSEEN emails
+            typ, data = self.connection.search(None, 'UNSEEN')
 
-        if typ != 'OK' or not data[0]:
-            return []
+            if typ != 'OK' or not data[0]:
+                return []
 
-        email_ids = data[0].split()[::-1]  # Reverse so newest emails (highest IDs) are processed first
-        logger.info(f'Finished search for unseen emails, found {len(email_ids)} emails to classify')
+            email_ids = data[0].split()[::-1]  # Reverse so newest emails (highest IDs) are processed first
+            logger.info(f'Finished search for unseen emails, found {len(email_ids)} emails to classify')
 
-        if not email_ids:
-            return []
+            if not email_ids:
+                return []
 
-        try:
-            BATCH_SIZE = int(os.getenv("IMAP_BATCH_SIZE") or "50")
-        except ValueError:
-            BATCH_SIZE = 50
+            try:
+                BATCH_SIZE = int(os.getenv("IMAP_BATCH_SIZE") or "50")
+            except ValueError:
+                BATCH_SIZE = 50
 
-        # ------------------------------------------------------------------
-        # Phase 1: metadata-only scan (no body download) newest-first.
-        # Collects qualifying sequence IDs and their gmail IDs up to limit.
-        #
-        # NOTE: IMAP FETCH returns results in ascending sequence-number order
-        # regardless of the order requested.  To honour newest-first we build
-        # a lookup dict from each batch response, then walk `batch_ids` (which
-        # *are* in newest-first order) to decide qualification order.
-        # ------------------------------------------------------------------
-        qualifying_seq_ids: List[bytes] = []
-        known_labels_set = set(known_labels)
+            # ------------------------------------------------------------------
+            # Phase 1: metadata-only scan (no body download) newest-first.
+            # Collects qualifying sequence IDs and their gmail IDs up to limit.
+            #
+            # NOTE: IMAP FETCH returns results in ascending sequence-number order
+            # regardless of the order requested.  To honour newest-first we build
+            # a lookup dict from each batch response, then walk `batch_ids` (which
+            # *are* in newest-first order) to decide qualification order.
+            # ------------------------------------------------------------------
+            qualifying_seq_ids: List[bytes] = []
+            known_labels_set = set(known_labels)
 
-        for i in range(0, len(email_ids), BATCH_SIZE):
-            batch_ids = email_ids[i:i + BATCH_SIZE]
-            ids_str = b','.join(batch_ids)
+            for i in range(0, len(email_ids), BATCH_SIZE):
+                batch_ids = email_ids[i:i + BATCH_SIZE]
+                ids_str = b','.join(batch_ids)
 
-            typ, msg_data = self.connection.fetch(ids_str, '(X-GM-LABELS X-GM-MSGID)')
-            if typ != 'OK':
-                continue
-
-            # Build a lookup: seq_id (str) -> labels_str
-            metadata_by_seq: Dict[str, str] = {}
-            for response_part in msg_data:
-                raw_line = response_part[0] if isinstance(response_part, tuple) else response_part
-                metadata = raw_line.decode('utf-8', errors='ignore')
-
-                seq_match = SEQ_PATTERN.match(metadata)
-                if not seq_match:
-                    continue
-                seq_id_str = seq_match.group(1)
-
-                labels_str = ""
-                lbl_match = X_GM_LABELS_PATTERN.search(metadata)
-                if lbl_match:
-                    labels_str = lbl_match.group(1)
-
-                metadata_by_seq[seq_id_str] = labels_str
-
-            # Walk batch_ids in newest-first order to preserve ordering
-            for bid in batch_ids:
-                bid_str = bid.decode('utf-8', errors='ignore')
-                if bid_str not in metadata_by_seq:
+                typ, msg_data = self.connection.fetch(ids_str, '(X-GM-LABELS X-GM-MSGID)')
+                if typ != 'OK':
                     continue
 
-                labels_str = metadata_by_seq[bid_str]
+                # Build a lookup: seq_id (str) -> labels_str
+                metadata_by_seq: Dict[str, str] = {}
+                for response_part in msg_data:
+                    raw_line = response_part[0] if isinstance(response_part, tuple) else response_part
+                    metadata = raw_line.decode('utf-8', errors='ignore')
 
-                # Skip if any known label is already applied
-                skip = False
-                for m in LABEL_TOKEN_PATTERN.finditer(labels_str):
-                    label_found = m.group(1).replace('\\"', '"').replace('\\\\', '\\') if m.group(1) else m.group(2)
-                    if label_found in known_labels_set:
-                        skip = True
-                        break
-
-                if not skip:
-                    qualifying_seq_ids.append(bid)
-                    if limit is not None and len(qualifying_seq_ids) >= limit:
-                        break  # got enough from this batch
-
-            if limit is not None and len(qualifying_seq_ids) >= limit:
-                break  # outer loop – got enough
-
-        if not qualifying_seq_ids:
-            return []
-
-        # ------------------------------------------------------------------
-        # Phase 2: fetch full bodies only for the qualifying emails.
-        #
-        # Again, IMAP returns results in ascending order, so we collect into
-        # a dict and then reassemble in qualifying_seq_ids order.
-        # ------------------------------------------------------------------
-        body_by_seq: Dict[str, Tuple[str, Message]] = {}
-
-        for i in range(0, len(qualifying_seq_ids), BATCH_SIZE):
-            batch_seq = qualifying_seq_ids[i:i + BATCH_SIZE]
-            ids_str = b','.join(batch_seq)
-
-            typ, msg_data = self.connection.fetch(ids_str, '(BODY.PEEK[] X-GM-MSGID)')
-            if typ != 'OK':
-                continue
-
-            for response_part in msg_data:
-                if isinstance(response_part, tuple):
-                    metadata = response_part[0].decode('utf-8', errors='ignore')
                     seq_match = SEQ_PATTERN.match(metadata)
-                    msgid_match = X_GM_MSGID_PATTERN.search(metadata)
-                    if not seq_match or not msgid_match:
+                    if not seq_match:
                         continue
                     seq_id_str = seq_match.group(1)
-                    gmail_id = msgid_match.group(1)
-                    raw_email = response_part[1]
-                    msg = email.message_from_bytes(raw_email)
-                    body_by_seq[seq_id_str] = (gmail_id, msg)
 
-        # Reassemble in newest-first order (matching qualifying_seq_ids)
-        results: List[Tuple[str, Message]] = []
-        for seq_id in qualifying_seq_ids:
-            key = seq_id.decode('utf-8', errors='ignore')
-            if key in body_by_seq:
-                results.append(body_by_seq[key])
+                    labels_str = ""
+                    lbl_match = X_GM_LABELS_PATTERN.search(metadata)
+                    if lbl_match:
+                        labels_str = lbl_match.group(1)
 
-        return results
+                    metadata_by_seq[seq_id_str] = labels_str
+
+                # Walk batch_ids in newest-first order to preserve ordering
+                for bid in batch_ids:
+                    bid_str = bid.decode('utf-8', errors='ignore')
+                    if bid_str not in metadata_by_seq:
+                        continue
+
+                    labels_str = metadata_by_seq[bid_str]
+
+                    # Skip if any known label is already applied
+                    skip = False
+                    for m in LABEL_TOKEN_PATTERN.finditer(labels_str):
+                        label_found = m.group(1).replace('\\"', '"').replace('\\\\', '\\') if m.group(1) else m.group(2)
+                        if label_found in known_labels_set:
+                            skip = True
+                            break
+
+                    if not skip:
+                        qualifying_seq_ids.append(bid)
+                        if limit is not None and len(qualifying_seq_ids) >= limit:
+                            break  # got enough from this batch
+
+                if limit is not None and len(qualifying_seq_ids) >= limit:
+                    break  # outer loop – got enough
+
+            if not qualifying_seq_ids:
+                return []
+
+            # ------------------------------------------------------------------
+            # Phase 2: fetch full bodies only for the qualifying emails.
+            #
+            # Again, IMAP returns results in ascending order, so we collect into
+            # a dict and then reassemble in qualifying_seq_ids order.
+            # ------------------------------------------------------------------
+            body_by_seq: Dict[str, Tuple[str, Message]] = {}
+
+            for i in range(0, len(qualifying_seq_ids), BATCH_SIZE):
+                batch_seq = qualifying_seq_ids[i:i + BATCH_SIZE]
+                ids_str = b','.join(batch_seq)
+
+                typ, msg_data = self.connection.fetch(ids_str, '(BODY.PEEK[] X-GM-MSGID)')
+                if typ != 'OK':
+                    continue
+
+                for response_part in msg_data:
+                    if isinstance(response_part, tuple):
+                        metadata = response_part[0].decode('utf-8', errors='ignore')
+                        seq_match = SEQ_PATTERN.match(metadata)
+                        msgid_match = X_GM_MSGID_PATTERN.search(metadata)
+                        if not seq_match or not msgid_match:
+                            continue
+                        seq_id_str = seq_match.group(1)
+                        gmail_id = msgid_match.group(1)
+                        raw_email = response_part[1]
+                        msg = email.message_from_bytes(raw_email)
+                        body_by_seq[seq_id_str] = (gmail_id, msg)
+
+            # Reassemble in newest-first order (matching qualifying_seq_ids)
+            results: List[Tuple[str, Message]] = []
+            for seq_id in qualifying_seq_ids:
+                key = seq_id.decode('utf-8', errors='ignore')
+                if key in body_by_seq:
+                    results.append(body_by_seq[key])
+
+            return results
+
+        return with_retry(
+            _do,
+            retries=3,
+            backoff=2.0,
+            exceptions=_IMAP_ERRORS,
+            on_retry=lambda exc, _: self._reset_connection(),
+        )
 
     def _search_by_gmail_id(self, gmail_id: str) -> bytes:
         """
         Helper to find the UID of an email given its X-GM-MSGID.
         Returns the UID as bytes, or None if not found.
+        Raises imaplib.IMAP4.error or OSError on connection failures.
         """
         self.connect()
-        try:
-            # Search for the UID corresponding to the X-GM-MSGID
-            typ, data = self.connection.uid('SEARCH', None, f'X-GM-MSGID {gmail_id}')
-            if typ == 'OK' and data[0]:
-                # Return the last one if multiple (shouldn't be multiple for one ID usually)
-                return data[0].split()[-1]
-        except imaplib.IMAP4.error as e:
-            print(f"Error searching for Gmail ID {gmail_id}: {e}")
+        typ, data = self.connection.uid('SEARCH', None, f'X-GM-MSGID {gmail_id}')
+        if typ == 'OK' and data[0]:
+            # Return the last one if multiple (shouldn't be multiple for one ID usually)
+            return data[0].split()[-1]
         return None
 
     def apply_label(self, gmail_id: str, label: str):
@@ -217,20 +232,27 @@ class GmailClient:
         Apply a label to the email using UID STORE +X-GM-LABELS.
         Accepts gmail_id (X-GM-MSGID).
         """
-        self.connect()
-
-        uid = self._search_by_gmail_id(gmail_id)
-        if not uid:
-            print(f"Could not find email with Gmail ID {gmail_id} to apply label.")
-            return
-
         # Quote label if it has spaces
         label_to_send = f'"{label}"' if " " in label else label
 
-        try:
+        def _do():
+            self.connect()
+            uid = self._search_by_gmail_id(gmail_id)
+            if not uid:
+                print(f"Could not find email with Gmail ID {gmail_id} to apply label.")
+                return
             typ, data = self.connection.uid('STORE', uid, '+X-GM-LABELS', f'({label_to_send})')
             if typ != 'OK':
-                print(f"Failed to apply label {label} to {gmail_id}: {data}")
+                raise imaplib.IMAP4.error(f"Failed to apply label {label} to {gmail_id}: {data}")
+
+        try:
+            with_retry(
+                _do,
+                retries=3,
+                backoff=2.0,
+                exceptions=_IMAP_ERRORS,
+                on_retry=lambda exc, _: self._reset_connection(),
+            )
         except Exception as e:
             print(f"Error applying label {label} to {gmail_id}: {e}")
 
@@ -239,20 +261,27 @@ class GmailClient:
         Remove a label from the email using UID STORE -X-GM-LABELS.
         Accepts gmail_id (X-GM-MSGID).
         """
-        self.connect()
-
-        uid = self._search_by_gmail_id(gmail_id)
-        if not uid:
-            print(f"Could not find email with Gmail ID {gmail_id} to remove label.")
-            return
-
         # Quote label if it has spaces
         label_to_send = f'"{label}"' if " " in label else label
 
-        try:
+        def _do():
+            self.connect()
+            uid = self._search_by_gmail_id(gmail_id)
+            if not uid:
+                print(f"Could not find email with Gmail ID {gmail_id} to remove label.")
+                return
             typ, data = self.connection.uid('STORE', uid, '-X-GM-LABELS', f'({label_to_send})')
             if typ != 'OK':
-                print(f"Failed to remove label {label} from {gmail_id}: {data}")
+                raise imaplib.IMAP4.error(f"Failed to remove label {label} from {gmail_id}: {data}")
+
+        try:
+            with_retry(
+                _do,
+                retries=3,
+                backoff=2.0,
+                exceptions=_IMAP_ERRORS,
+                on_retry=lambda exc, _: self._reset_connection(),
+            )
         except Exception as e:
             print(f"Error removing label {label} from {gmail_id}: {e}")
 
@@ -260,20 +289,30 @@ class GmailClient:
         """
         Fetch the email content for a given X-GM-MSGID.
         """
-        self.connect()
-        uid = self._search_by_gmail_id(gmail_id)
-        if not uid:
-            return None
+        def _do():
+            self.connect()
+            uid = self._search_by_gmail_id(gmail_id)
+            if not uid:
+                return None
 
-        try:
             # Fetch BODY.PEEK[] based on UID
             typ, msg_data = self.connection.uid('FETCH', uid, '(BODY.PEEK[])')
             if typ != 'OK':
                 return None
-            
+
             for response_part in msg_data:
                 if isinstance(response_part, tuple):
                     return email.message_from_bytes(response_part[1])
+            return None
+
+        try:
+            return with_retry(
+                _do,
+                retries=3,
+                backoff=2.0,
+                exceptions=_IMAP_ERRORS,
+                on_retry=lambda exc, _: self._reset_connection(),
+            )
         except Exception as e:
             print(f"Error fetching email {gmail_id}: {e}")
             return None
@@ -283,46 +322,46 @@ class GmailClient:
         Fetch current labels for a list of Gmail IDs (X-GM-MSGID).
         Returns {gmail_id: [label1, label2, ...]}
         """
-        self.connect()
-        results = {}
+        def _do():
+            self.connect()
+            results = {}
 
-        # Batch search for UIDs using OR logic
-        # SEARCH (X-GM-MSGID 1 OR X-GM-MSGID 2 ...)
-        # We need to construct this carefully to not exceed line length limits.
-        # But usually IMAP libs handle large commands or we batch search too.
+            # Batch search for UIDs using OR logic
+            # SEARCH (X-GM-MSGID 1 OR X-GM-MSGID 2 ...)
+            # We need to construct this carefully to not exceed line length limits.
+            # But usually IMAP libs handle large commands or we batch search too.
 
-        uid_to_gmail_id = {}
-        uids_to_fetch = []
+            uid_to_gmail_id = {}
+            uids_to_fetch = []
 
-        # Batch the SEARCH command too
-        SEARCH_BATCH = 50
-        for i in range(0, len(gmail_ids), SEARCH_BATCH):
-            batch_gids = gmail_ids[i:i+SEARCH_BATCH]
+            # Batch the SEARCH command too
+            SEARCH_BATCH = 50
+            for i in range(0, len(gmail_ids), SEARCH_BATCH):
+                batch_gids = gmail_ids[i:i+SEARCH_BATCH]
 
-            # Construct search criteria
-            # Logic: (OR X-GM-MSGID <id> (OR X-GM-MSGID <id> ...))
-            # Or simpler: OR OR OR (if library supports raw string)
-            # Standard IMAP search for multiple items is often OR key1 OR key2 ...
-            # But the OR operator takes two arguments.
-            # So for N items, we need N-1 ORs nested or chained?
-            # Actually, `SEARCH OR <key> <key>` only works for 2?
-            # RFC 3501: OR <search-key> <search-key>
-            # So for 3 items: OR <key1> OR <key2> <key3>
-            # For N items: (N-1) "OR " prefixes followed by N keys.
+                # Construct search criteria
+                # Logic: (OR X-GM-MSGID <id> (OR X-GM-MSGID <id> ...))
+                # Or simpler: OR OR OR (if library supports raw string)
+                # Standard IMAP search for multiple items is often OR key1 OR key2 ...
+                # But the OR operator takes two arguments.
+                # So for N items, we need N-1 ORs nested or chained?
+                # Actually, `SEARCH OR <key> <key>` only works for 2?
+                # RFC 3501: OR <search-key> <search-key>
+                # So for 3 items: OR <key1> OR <key2> <key3>
+                # For N items: (N-1) "OR " prefixes followed by N keys.
 
-            if not batch_gids:
-                continue
+                if not batch_gids:
+                    continue
 
-            if len(batch_gids) == 1:
-                criteria = f'X-GM-MSGID {batch_gids[0]}'
-            else:
-                # Prefix (N-1) times "OR"
-                # Example for [1, 2, 3]: OR X-GM-MSGID 1 OR X-GM-MSGID 2 X-GM-MSGID 3
-                prefixes = "OR " * (len(batch_gids) - 1)
-                keys = " ".join([f'X-GM-MSGID {gid}' for gid in batch_gids])
-                criteria = f'{prefixes}{keys}'
+                if len(batch_gids) == 1:
+                    criteria = f'X-GM-MSGID {batch_gids[0]}'
+                else:
+                    # Prefix (N-1) times "OR"
+                    # Example for [1, 2, 3]: OR X-GM-MSGID 1 OR X-GM-MSGID 2 X-GM-MSGID 3
+                    prefixes = "OR " * (len(batch_gids) - 1)
+                    keys = " ".join([f'X-GM-MSGID {gid}' for gid in batch_gids])
+                    criteria = f'{prefixes}{keys}'
 
-            try:
                 # We need to fetch UIDs and ideally X-GM-MSGID in the response to map them back?
                 # SEARCH returns only IDs (UIDs). It doesn't tell us which criteria matched which ID.
                 # So we have to fetch X-GM-MSGID for the found UIDs to rebuild the map.
@@ -332,20 +371,17 @@ class GmailClient:
                     found_uids = data[0].split()
                     if found_uids:
                         uids_to_fetch.extend(found_uids)
-            except Exception as e:
-                print(f"Error batch searching UIDs: {e}")
 
-        if not uids_to_fetch:
-            return results
+            if not uids_to_fetch:
+                return results
 
-        # Fetch in batches (re-using uids found from search)
-        # We fetch X-GM-MSGID again to map UID -> GmailID reliably
-        BATCH_SIZE = 50
-        for i in range(0, len(uids_to_fetch), BATCH_SIZE):
-            batch_uids = uids_to_fetch[i:i+BATCH_SIZE]
-            uid_str = b','.join(batch_uids)
+            # Fetch in batches (re-using uids found from search)
+            # We fetch X-GM-MSGID again to map UID -> GmailID reliably
+            BATCH_SIZE = 50
+            for i in range(0, len(uids_to_fetch), BATCH_SIZE):
+                batch_uids = uids_to_fetch[i:i+BATCH_SIZE]
+                uid_str = b','.join(batch_uids)
 
-            try:
                 typ, data = self.connection.uid('FETCH', uid_str, '(X-GM-MSGID X-GM-LABELS)')
                 if typ != 'OK':
                     continue
@@ -375,10 +411,20 @@ class GmailClient:
                                 labels.append(m.group(2))
 
                     results[gid] = labels
-            except Exception as e:
-                print(f"Error fetching labels batch: {e}")
 
-        return results
+            return results
+
+        try:
+            return with_retry(
+                _do,
+                retries=3,
+                backoff=2.0,
+                exceptions=_IMAP_ERRORS,
+                on_retry=lambda exc, _: self._reset_connection(),
+            )
+        except Exception as e:
+            print(f"Error fetching labels batch: {e}")
+            return {}
 
     def scan_labeled_emails(self, known_labels: List[str]) -> Dict[str, Tuple[List[str], Message]]:
         """
@@ -388,37 +434,34 @@ class GmailClient:
         This is used to discover emails that have labels applied in Gmail
         but are missing from the local database (e.g. after a DB reset).
         """
-        self.connect()
-        results: Dict[str, Tuple[List[str], Message]] = {}
+        def _do():
+            self.connect()
+            results: Dict[str, Tuple[List[str], Message]] = {}
 
-        all_uids = set()
+            all_uids = set()
 
-        # Search for each known label
-        for label in known_labels:
-            try:
+            # Search for each known label
+            for label in known_labels:
                 # X-GM-LABELS requires the label to be quoted
                 criteria = f'X-GM-LABELS "{label}"'
                 typ, data = self.connection.uid('SEARCH', None, criteria)
                 if typ == 'OK' and data[0]:
                     found_uids = data[0].split()
                     all_uids.update(found_uids)
-            except Exception as e:
-                logger.warning(f"Error searching for label '{label}': {e}")
 
-        if not all_uids:
-            return results
+            if not all_uids:
+                return results
 
-        logger.info(f"Found {len(all_uids)} unique emails with known labels in IMAP.")
+            logger.info(f"Found {len(all_uids)} unique emails with known labels in IMAP.")
 
-        # Batch fetch: get BODY, X-GM-MSGID, and X-GM-LABELS for all found UIDs
-        uids_list = list(all_uids)
-        BATCH_SIZE = 50
+            # Batch fetch: get BODY, X-GM-MSGID, and X-GM-LABELS for all found UIDs
+            uids_list = list(all_uids)
+            BATCH_SIZE = 50
 
-        for i in range(0, len(uids_list), BATCH_SIZE):
-            batch_uids = uids_list[i:i + BATCH_SIZE]
-            uid_str = b','.join(batch_uids)
+            for i in range(0, len(uids_list), BATCH_SIZE):
+                batch_uids = uids_list[i:i + BATCH_SIZE]
+                uid_str = b','.join(batch_uids)
 
-            try:
                 typ, data = self.connection.uid(
                     'FETCH', uid_str, '(BODY.PEEK[] X-GM-MSGID X-GM-LABELS)'
                 )
@@ -456,10 +499,19 @@ class GmailClient:
 
                     results[gid] = (labels, msg)
 
-            except Exception as e:
-                logger.warning(f"Error fetching labeled emails batch: {e}")
+            return results
 
-        return results
+        try:
+            return with_retry(
+                _do,
+                retries=3,
+                backoff=2.0,
+                exceptions=_IMAP_ERRORS,
+                on_retry=lambda exc, _: self._reset_connection(),
+            )
+        except Exception as e:
+            logger.warning(f"Error scanning labeled emails after retries: {e}")
+            return {}
 
 
 # Module-level singleton — shared across all background jobs so that a single

--- a/email_classifier_brain/jobs/training_data.py
+++ b/email_classifier_brain/jobs/training_data.py
@@ -16,6 +16,7 @@ import config
 import database
 from config import TRAINING_DATA_DIR
 from job_queue import job_queue
+from retry import with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +96,16 @@ def push_training_data_to_git():
                 "-m", f"Auto-update training data: {datetime.datetime.now().isoformat()}"
             ], cwd=TRAINING_DATA_DIR, check=True, capture_output=True)
             logger.info("Pushing to remote...")
-            subprocess.run(["git", "push"], cwd=TRAINING_DATA_DIR, check=True, capture_output=True)
+            with_retry(
+                subprocess.run,
+                ["git", "push"],
+                cwd=TRAINING_DATA_DIR,
+                check=True,
+                capture_output=True,
+                retries=3,
+                backoff=5.0,
+                exceptions=(subprocess.CalledProcessError, OSError),
+            )
             logger.info("Training data pushed successfully.")
         else:
             logger.info("No changes to push in training data.")

--- a/email_classifier_brain/retry.py
+++ b/email_classifier_brain/retry.py
@@ -1,0 +1,43 @@
+"""
+retry.py — Generic retry utility with exponential backoff.
+"""
+
+import logging
+import time
+from typing import Callable, Optional, Tuple, Type
+
+logger = logging.getLogger(__name__)
+
+
+def with_retry(
+    fn: Callable,
+    *args,
+    retries: int = 3,
+    backoff: float = 1.0,
+    exceptions: Tuple[Type[BaseException], ...] = (Exception,),
+    on_retry: Optional[Callable] = None,
+    **kwargs,
+):
+    """
+    Call ``fn(*args, **kwargs)``, retrying on *exceptions* with exponential backoff.
+
+    :param fn: callable to invoke
+    :param retries: total number of attempts (default 3)
+    :param backoff: base wait in seconds; doubles each attempt (default 1.0)
+    :param exceptions: exception types that trigger a retry
+    :param on_retry: optional callable(exc, attempt) invoked before each sleep
+    """
+    for attempt in range(1, retries + 1):
+        try:
+            return fn(*args, **kwargs)
+        except exceptions as exc:
+            if attempt >= retries:
+                raise
+            if on_retry is not None:
+                on_retry(exc, attempt)
+            wait = backoff * (2 ** (attempt - 1))
+            logger.warning(
+                "Attempt %d/%d failed (%s: %s). Retrying in %.1fs...",
+                attempt, retries, type(exc).__name__, exc, wait,
+            )
+            time.sleep(wait)

--- a/email_classifier_brain/tests/test_retry.py
+++ b/email_classifier_brain/tests/test_retry.py
@@ -1,0 +1,175 @@
+"""
+Tests for the retry utility and IMAP retry behaviour.
+"""
+
+import imaplib
+import os
+import sys
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from retry import with_retry
+import imap_client
+
+
+# ---------------------------------------------------------------------------
+# with_retry unit tests
+# ---------------------------------------------------------------------------
+
+@patch('retry.time.sleep')
+def test_with_retry_success_on_first_attempt(mock_sleep):
+    """Function that succeeds immediately — no sleep, no on_retry."""
+    fn = MagicMock(return_value=42)
+    result = with_retry(fn, retries=3, backoff=1.0, exceptions=(ValueError,))
+    assert result == 42
+    fn.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+@patch('retry.time.sleep')
+def test_with_retry_retries_on_exception(mock_sleep):
+    """Function fails once then succeeds — retried exactly once."""
+    fn = MagicMock(side_effect=[ValueError("oops"), 99])
+    result = with_retry(fn, retries=3, backoff=1.0, exceptions=(ValueError,))
+    assert result == 99
+    assert fn.call_count == 2
+    mock_sleep.assert_called_once_with(1.0)  # backoff * 2^0
+
+
+@patch('retry.time.sleep')
+def test_with_retry_raises_after_exhausting_retries(mock_sleep):
+    """After all attempts are exhausted the original exception is re-raised."""
+    fn = MagicMock(side_effect=OSError("network down"))
+    with pytest.raises(OSError, match="network down"):
+        with_retry(fn, retries=3, backoff=1.0, exceptions=(OSError,))
+    assert fn.call_count == 3
+
+
+@patch('retry.time.sleep')
+def test_with_retry_exponential_backoff(mock_sleep):
+    """Sleep durations double on each attempt: backoff, backoff*2, ..."""
+    fn = MagicMock(side_effect=[OSError(), OSError(), OSError()])
+    with pytest.raises(OSError):
+        with_retry(fn, retries=3, backoff=2.0, exceptions=(OSError,))
+    assert mock_sleep.call_args_list == [call(2.0), call(4.0)]
+
+
+@patch('retry.time.sleep')
+def test_with_retry_calls_on_retry_callback(mock_sleep):
+    """on_retry is invoked with (exc, attempt) before each sleep."""
+    on_retry = MagicMock()
+    exc1 = ValueError("first")
+    exc2 = ValueError("second")
+    fn = MagicMock(side_effect=[exc1, exc2, "ok"])
+    result = with_retry(fn, retries=3, backoff=0.5, exceptions=(ValueError,), on_retry=on_retry)
+    assert result == "ok"
+    assert on_retry.call_count == 2
+    on_retry.assert_any_call(exc1, 1)
+    on_retry.assert_any_call(exc2, 2)
+
+
+@patch('retry.time.sleep')
+def test_with_retry_does_not_catch_other_exceptions(mock_sleep):
+    """Exceptions not listed in *exceptions* are not retried."""
+    fn = MagicMock(side_effect=RuntimeError("fatal"))
+    with pytest.raises(RuntimeError, match="fatal"):
+        with_retry(fn, retries=3, backoff=1.0, exceptions=(OSError,))
+    fn.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# IMAP retry integration tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_imap_conn():
+    with patch('imaplib.IMAP4_SSL') as MockIMAP:
+        yield MockIMAP.return_value
+
+
+@pytest.fixture
+def client(mock_imap_conn):
+    with patch.dict(os.environ, {"IMAP_USER": "test@example.com", "IMAP_PASSWORD": "pass"}):
+        c = imap_client.GmailClient()
+        c.connection = mock_imap_conn
+        return c
+
+
+@patch('retry.time.sleep')
+def test_fetch_unprocessed_emails_retries_on_imap_error(mock_sleep, client, mock_imap_conn):
+    """fetch_unprocessed_emails should retry on IMAP4.error and reconnect."""
+    # First call raises, second succeeds with empty inbox
+    mock_imap_conn.noop.return_value = ('OK', [b''])
+    mock_imap_conn.search.side_effect = [
+        imaplib.IMAP4.error("connection reset"),
+        ('OK', [b'']),  # second attempt: no unseen emails
+    ]
+
+    result = client.fetch_unprocessed_emails(known_labels=[])
+
+    assert result == []
+    assert mock_imap_conn.search.call_count == 2
+    mock_sleep.assert_called_once()  # one sleep between attempts
+
+
+@patch('retry.time.sleep')
+def test_fetch_unprocessed_emails_raises_after_all_retries(mock_sleep, client, mock_imap_conn):
+    """fetch_unprocessed_emails re-raises after all retry attempts are exhausted."""
+    mock_imap_conn.noop.return_value = ('OK', [b''])
+    mock_imap_conn.search.side_effect = imaplib.IMAP4.error("server gone")
+
+    with pytest.raises(imaplib.IMAP4.error):
+        client.fetch_unprocessed_emails(known_labels=[])
+
+    assert mock_imap_conn.search.call_count == 3  # 3 attempts
+
+
+@patch('retry.time.sleep')
+def test_fetch_unprocessed_emails_resets_connection_on_retry(mock_sleep, client, mock_imap_conn):
+    """_reset_connection is called between attempts, forcing a fresh connect."""
+    mock_imap_conn.noop.return_value = ('OK', [b''])
+    mock_imap_conn.search.side_effect = [
+        OSError("broken pipe"),
+        ('OK', [b'']),
+    ]
+
+    client.fetch_unprocessed_emails(known_labels=[])
+
+    # After the reset the connection is None; connect() opens a new one.
+    # We verify noop was called at least once (from connect()) and that
+    # we went through two search calls.
+    assert mock_imap_conn.search.call_count == 2
+
+
+@patch('retry.time.sleep')
+def test_apply_label_retries_on_imap_error(mock_sleep, client, mock_imap_conn):
+    """apply_label should retry the STORE command on IMAP error."""
+    mock_imap_conn.noop.return_value = ('OK', [b''])
+    # UID SEARCH succeeds, then STORE fails once then succeeds
+    mock_imap_conn.uid.side_effect = [
+        ('OK', [b'42']),           # search — attempt 1
+        imaplib.IMAP4.error("store failed"),  # store — attempt 1
+        ('OK', [b'42']),           # search — attempt 2 (after reconnect)
+        ('OK', [b'OK']),           # store — attempt 2
+    ]
+
+    client.apply_label('123456', 'WORK')
+    assert mock_imap_conn.uid.call_count == 4
+
+
+@patch('retry.time.sleep')
+def test_get_labels_for_emails_retries_on_oserror(mock_sleep, client, mock_imap_conn):
+    """get_labels_for_emails should retry on OSError."""
+    mock_imap_conn.noop.return_value = ('OK', [b''])
+    mock_imap_conn.uid.side_effect = [
+        OSError("network reset"),
+        ('OK', [b'']),  # second attempt: no UIDs found
+    ]
+
+    result = client.get_labels_for_emails(['123'])
+    assert result == {}
+    assert mock_imap_conn.uid.call_count == 2


### PR DESCRIPTION
Closes #44

Adds retry logic with exponential backoff for all IMAP operations, git push, and SQLite connections:

- New `retry.py` utility with `with_retry()` function
- All six public `GmailClient` methods retry up to 3x on transient IMAP/OSX errors, resetting the connection before each retry
- `git push` retries up to 3x with 5s base backoff
- SQLite connection timeout set to 10s to handle lock contention
- Tests for the retry utility and IMAP retry integration

Generated with [Claude Code](https://claude.ai/code)