### PR TITLE
feat: bypass API key auth for localhost and Tailscale

### DIFF
--- a/email_classifier_brain/api/routes/health.py
+++ b/email_classifier_brain/api/routes/health.py
@@ -7,7 +7,6 @@ Health check endpoint and classification statistics.
 
 import datetime
 import logging
-import os
 from typing import Optional
 
 import classify
@@ -17,7 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Security
 from fastapi.responses import JSONResponse
 
 from api.models import StatsResponse
-from api.security import api_key_scheme, get_api_key, is_trusted_ip
+from api.security import api_key_scheme, get_api_key, is_trusted_ip, is_valid_admin_key
 
 logger = logging.getLogger(__name__)
 
@@ -43,10 +42,8 @@ def health_check(
     if check_imap:
         client_ip = request.client.host if request.client else None
         trusted = client_ip and is_trusted_ip(client_ip)
-        if not trusted:
-            expected_key = os.getenv("ADMIN_API_KEY")
-            if not expected_key or api_key != expected_key:
-                raise HTTPException(status_code=401, detail="X-API-Key required to use check_imap")
+        if not trusted and not is_valid_admin_key(api_key):
+            raise HTTPException(status_code=401, detail="X-API-Key required to use check_imap")
 
     checks: dict = {}
     critical_ok = True

--- a/email_classifier_brain/api/routes/health.py
+++ b/email_classifier_brain/api/routes/health.py
@@ -13,11 +13,11 @@ from typing import Optional
 import classify
 import database
 import imap_client
-from fastapi import APIRouter, Depends, HTTPException, Query, Security
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Security
 from fastapi.responses import JSONResponse
 
 from api.models import StatsResponse
-from api.security import api_key_scheme, get_api_key
+from api.security import api_key_scheme, get_api_key, is_trusted_ip
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ router = APIRouter()
 
 @router.get("/health")
 def health_check(
+    request: Request,
     check_imap: bool = Query(False, description="Also verify IMAP connectivity (requires X-API-Key)"),
     api_key: str = Security(api_key_scheme),
 ):
@@ -40,9 +41,12 @@ def health_check(
     """
     # IMAP check is gated behind authentication to prevent unauthenticated DoS
     if check_imap:
-        expected_key = os.getenv("ADMIN_API_KEY")
-        if not expected_key or api_key != expected_key:
-            raise HTTPException(status_code=401, detail="X-API-Key required to use check_imap")
+        client_ip = request.client.host if request.client else None
+        trusted = client_ip and is_trusted_ip(client_ip)
+        if not trusted:
+            expected_key = os.getenv("ADMIN_API_KEY")
+            if not expected_key or api_key != expected_key:
+                raise HTTPException(status_code=401, detail="X-API-Key required to use check_imap")
 
     checks: dict = {}
     critical_ok = True

--- a/email_classifier_brain/api/security.py
+++ b/email_classifier_brain/api/security.py
@@ -33,6 +33,14 @@ def is_trusted_ip(ip: str) -> bool:
         return False
 
 
+def is_valid_admin_key(api_key: str | None) -> bool:
+    """Check if the provided API key matches ADMIN_API_KEY from the environment."""
+    expected_key = os.getenv("ADMIN_API_KEY")
+    if not expected_key:
+        return False
+    return api_key == expected_key
+
+
 def get_api_key(
     request: Request,
     api_key: str = Security(api_key_scheme),

--- a/email_classifier_brain/api/security.py
+++ b/email_classifier_brain/api/security.py
@@ -3,24 +3,49 @@ api/security.py — API Key Authentication
 ==========================================
 
 Provides the API key dependency used to protect admin endpoints.
+Requests from localhost or Tailscale CGNAT range bypass the key check.
 """
 
 import logging
 import os
+from ipaddress import ip_address, ip_network
 
-from fastapi import HTTPException, Security
+from fastapi import HTTPException, Request, Security
 from fastapi.security import APIKeyHeader
 
 logger = logging.getLogger(__name__)
 
 api_key_scheme = APIKeyHeader(name="X-API-Key", auto_error=False)
 
+TRUSTED_NETWORKS = [
+    ip_network("127.0.0.0/8"),
+    ip_network("::1/128"),
+    ip_network("100.64.0.0/10"),  # Tailscale CGNAT range
+]
 
-def get_api_key(api_key: str = Security(api_key_scheme)):
+
+def is_trusted_ip(ip: str) -> bool:
+    """Return True if the IP belongs to localhost or Tailscale."""
+    try:
+        addr = ip_address(ip)
+        return any(addr in net for net in TRUSTED_NETWORKS)
+    except ValueError:
+        return False
+
+
+def get_api_key(
+    request: Request,
+    api_key: str = Security(api_key_scheme),
+):
     """
     Validates the API key against ADMIN_API_KEY in the environment.
-    If ADMIN_API_KEY is not set, access is denied (500).
+    Requests from trusted networks (localhost, Tailscale) skip the check.
+    If ADMIN_API_KEY is not set, access is denied (500) for untrusted clients.
     """
+    client_ip = request.client.host if request.client else None
+    if client_ip and is_trusted_ip(client_ip):
+        return api_key or "trusted-network"
+
     expected_key = os.getenv("ADMIN_API_KEY")
     if not expected_key:
         logger.error("ADMIN_API_KEY not set in environment. Blocking admin access.")


### PR DESCRIPTION
## Summary
- Requests from trusted networks (localhost `127.0.0.0/8`, `::1`, Tailscale CGNAT `100.64.0.0/10`) now bypass the `X-API-Key` check
- Adds `is_trusted_ip()` helper to `api/security.py` and updates `get_api_key` dependency
- Updates the health endpoint's inline IMAP auth gate to also trust these networks

## Test plan
- [x] Existing auth tests pass (4/4) — TestClient uses a non-trusted IP, so key validation is still enforced in tests
- [ ] Verify on Pi: `curl http://localhost:8008/stats` returns 200 without `X-API-Key` header
- [ ] Verify from Tailscale: `curl http://jarvis:8008/stats` returns 200 without key
- [ ] Verify from external IP: requests without key still get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)